### PR TITLE
Feature/migrate to gulp v 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,21 @@ const lazyTaskBuilder = require('gulp-lazy-init');
 const ENABLE_LAZY = true; // by default
 const task = lazyTaskBuilder(gulp, path.join(__dirname, '/gulp', ENABLE_LAZY));
 
-gulp.task('test', 'test code of the project', [
-  task('test-scripts')
-]);
+exports.test = task.series(
+  task('test-scripts'),
+  task.series(
+    task('test-scripts'),
+    task('test-scripts'),
+  ),
+  task.parallel(
+    task.series(
+      task('test-scripts'),
+      task('test-scripts'),
+    ),
+    task('test-scripts'),
+    task('test-scripts'),
+  ),
+  task('test-scripts'),
+);
 
 ```

--- a/gulp/test-scripts.js
+++ b/gulp/test-scripts.js
@@ -3,13 +3,12 @@
 const gulp = require('gulp');
 const gulpEslint = require('gulp-eslint');
 
-module.exports = (callback) =>
-  gulp
-    .src([
-      '**/*.js',
-      '!**/*scsslint*',
-      '!nodex_modules/**/*'
-    ])
-    .pipe(gulpEslint())
-    .pipe(gulpEslint.format())
-    .pipe(gulpEslint.failAfterError());
+let counter = 0;
+module.exports = (callback) => {
+  let c = counter++;
+  console.log('RUN TEST SCRIPTS ' + c + ' STARTS');
+  setTimeout(function () {
+    console.log('RUN TEST SCRIPTS ' + c + ' DONE');
+    callback();
+  }, 1000);
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,24 +3,23 @@
 
 const path = require('path');
 const lazyTaskBuilder = require('./index');
-const gulp = require('gulp-help')(require('gulp'), {
-  description: '',
-  hideEmpty: true,
-  hideDepsMessage: true
-});
+const gulp = require('gulp');
 
 const task = lazyTaskBuilder(gulp, path.join(__dirname, '/gulp'));
 
-
-
-
-gulp.task('default', [
-  'help'
-]);
-
-
-
-
-gulp.task('test', 'test code of the project', [
-  task('test-scripts')
-]);
+exports.test = task.series(
+  task('test-scripts'),
+  task.series(
+    task('test-scripts'),
+    task('test-scripts'),
+  ),
+  task.parallel(
+    task.series(
+      task('test-scripts'),
+      task('test-scripts'),
+    ),
+    task('test-scripts'),
+    task('test-scripts'),
+  ),
+  task('test-scripts'),
+);

--- a/package.json
+++ b/package.json
@@ -30,14 +30,10 @@
   },
   "homepage": "https://github.com/aliaksandr-master/gulp-lazy-init#readme",
   "devDependencies": {
-    "babel-eslint": "^6.1.2",
-    "eslint-config-eslint": "^3.0.0",
-    "eslint-plugin-require-path-exists": "^1.1.5",
-    "gulp": "^3.9.1",
-    "gulp-eslint": "^3.0.1",
-    "gulp-help": "^1.6.1"
+    "babel-eslint": "^10.0.3",
+    "eslint-config-eslint": "^5.0.1",
+    "eslint-plugin-require-path-exists": "^1.1.9",
+    "gulp": "^4.0.2",
+    "gulp-eslint": "^6.0.0"
   },
-  "dependencies": {
-    "run-sequence": "^1.2.2"
-  }
 }


### PR DESCRIPTION
Migrate to gulp 4:
removed gulp-help
added support for gulp.series and gulp.parallel